### PR TITLE
chore: add StackBlitz button

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A basic playground built with [ruby.wasm](https://github.com/ruby/ruby.wasm).
 
 ## Development
 
+[![Open in Codeflow](https://developer.stackblitz.com/img/open_in_codeflow.svg)](https:///pr.new/skryukov/ruby-wasi-playground)
+
 To run project locally:
 
 1. Install Node.js by [`asdf`](https://github.com/asdf-vm/asdf) or manually:


### PR DESCRIPTION
This PR adds [![Open in Codeflow](https://developer.stackblitz.com/img/open_in_codeflow.svg)](https:///pr.new/skryukov/ruby-wasi-playground) button to the readme