### PR TITLE
Fix small typo in editor text

### DIFF
--- a/src/engines/wasi/editorFS.ts
+++ b/src/engines/wasi/editorFS.ts
@@ -46,7 +46,7 @@ const defaultGem = gemFromURI() || gem;
 
 const defaultCode = `# This is a Ruby WASI playground
 # You can run any Ruby code here and see the result
-# You can also install gems using Gemfile an the "Bundle install" button.
+# You can also install gems using a Gemfile and the "Bundle install" button.
 
 require "${defaultGem}"
 ${defaultGem === gem ? gemCode : ''}`;


### PR DESCRIPTION
Adds a missing "a" and updates "an" to "and"

I was testing this out after seeing the post in Ruby Weekly. This is a really cool project!