### PR TITLE
Set `Encoding.default_external` to `UTF-8`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "ruby-wasi-playground",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ruby-wasi-playground",
-      "version": "0.0.0",
+      "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@appsignal/javascript": "^1.3.28",
         "@bjorn3/browser_wasi_shim": "^0.2.19",

--- a/src/engines/wasi/wasi.ts
+++ b/src/engines/wasi/wasi.ts
@@ -52,7 +52,7 @@ async function createRuby(setStdout: TSetString, setStderr: TSetString) {
   await ruby.setInstance(instance);
 
   wasi.initialize(instance as never);
-  ruby.initialize(["ruby.wasm", "-e_=0", `-I${rubyStubsPath}`, `-rdefault_stubs`]);
+  ruby.initialize(["ruby.wasm", "-e_=0", "-EUTF-8", `-I${rubyStubsPath}`, `-rdefault_stubs`]);
 
   return ruby;
 }


### PR DESCRIPTION
This PR sets `Encoding.default_external` to `UTF-8`: https://github.com/ruby/ruby.wasm/blob/0db31bcb62b51b3ef21d5285e1c1ba4934caced2/packages/npm-packages/ruby-wasm-wasi/src/vm.ts#L88