### PR TITLE
upgrade ruby wasm and browser_wasi_shim versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@appsignal/javascript": "^1.3.28",
-        "@bjorn3/browser_wasi_shim": "^0.2.19",
+        "@bjorn3/browser_wasi_shim": "^0.3.0",
         "@monaco-editor/react": "^4.4.4",
         "@nanostores/react": "^0.7.1",
-        "@ruby/3.3-wasm-wasi": "^2.5.0",
+        "@ruby/3.3-wasm-wasi": "^2.6.2",
         "@ruby/wasm-wasi": "^2.5.0",
         "dexie": "^3.2.5",
         "dexie-react-hooks": "^1.1.7",
@@ -410,9 +410,9 @@
       }
     },
     "node_modules/@bjorn3/browser_wasi_shim": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.19.tgz",
-      "integrity": "sha512-Zu5KVxRp7MBwwdOtXSmu14NUwPASNE6zK/BSwWKf0Fsc4g5NOqPYto5C0Nc6EixDb0AEXCoLFDMKP9RN7n2yPQ=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.3.0.tgz",
+      "integrity": "sha512-FlRBYttPRLcWORzBe6g8nmYTafBkOEFeOqMYM4tAHJzFsQy4+xJA94z85a9BCs8S+Uzfh9LrkpII7DXr2iUVFg=="
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -920,17 +920,20 @@
       ]
     },
     "node_modules/@ruby/3.3-wasm-wasi": {
-      "version": "2.5.0",
-      "license": "MIT",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@ruby/3.3-wasm-wasi/-/3.3-wasm-wasi-2.6.2.tgz",
+      "integrity": "sha512-HyJ3nIlciQ1FnF2RBKEHwMKtCzgbD1EjCxiCFntpoN6VLAVZNJe/uTsTj4XZRcUPov272fg33YERhiu/abtffQ==",
       "dependencies": {
         "@ruby/wasm-wasi": "^2.0.0"
       }
     },
     "node_modules/@ruby/wasm-wasi": {
-      "version": "2.5.0",
-      "license": "MIT",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@ruby/wasm-wasi/-/wasm-wasi-2.6.2.tgz",
+      "integrity": "sha512-+y8uCYbtvDZZEU8VxM9JX6KoZJTvfmcEhRTIXdkxXwp/NFR7EE21pBEVYU+zzhCyKxRbmXp83BeTAYZuxe++HQ==",
       "dependencies": {
-        "tslib": "^2.6.1"
+        "@bjorn3/browser_wasi_shim": "^0.3.0",
+        "tslib": "^2.6.3"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -4798,8 +4801,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "license": "0BSD"
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5489,9 +5493,9 @@
       }
     },
     "@bjorn3/browser_wasi_shim": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.2.19.tgz",
-      "integrity": "sha512-Zu5KVxRp7MBwwdOtXSmu14NUwPASNE6zK/BSwWKf0Fsc4g5NOqPYto5C0Nc6EixDb0AEXCoLFDMKP9RN7n2yPQ=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.3.0.tgz",
+      "integrity": "sha512-FlRBYttPRLcWORzBe6g8nmYTafBkOEFeOqMYM4tAHJzFsQy4+xJA94z85a9BCs8S+Uzfh9LrkpII7DXr2iUVFg=="
     },
     "@colors/colors": {
       "version": "1.5.0",
@@ -5842,15 +5846,20 @@
       "optional": true
     },
     "@ruby/3.3-wasm-wasi": {
-      "version": "2.5.0",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@ruby/3.3-wasm-wasi/-/3.3-wasm-wasi-2.6.2.tgz",
+      "integrity": "sha512-HyJ3nIlciQ1FnF2RBKEHwMKtCzgbD1EjCxiCFntpoN6VLAVZNJe/uTsTj4XZRcUPov272fg33YERhiu/abtffQ==",
       "requires": {
         "@ruby/wasm-wasi": "^2.0.0"
       }
     },
     "@ruby/wasm-wasi": {
-      "version": "2.5.0",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@ruby/wasm-wasi/-/wasm-wasi-2.6.2.tgz",
+      "integrity": "sha512-+y8uCYbtvDZZEU8VxM9JX6KoZJTvfmcEhRTIXdkxXwp/NFR7EE21pBEVYU+zzhCyKxRbmXp83BeTAYZuxe++HQ==",
       "requires": {
-        "tslib": "^2.6.1"
+        "@bjorn3/browser_wasi_shim": "^0.3.0",
+        "tslib": "^2.6.3"
       }
     },
     "@socket.io/component-emitter": {
@@ -8576,7 +8585,9 @@
       "requires": {}
     },
     "tslib": {
-      "version": "2.6.2"
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   },
   "dependencies": {
     "@appsignal/javascript": "^1.3.28",
-    "@bjorn3/browser_wasi_shim": "^0.2.19",
+    "@bjorn3/browser_wasi_shim": "^0.3.0",
     "@monaco-editor/react": "^4.4.4",
     "@nanostores/react": "^0.7.1",
-    "@ruby/3.3-wasm-wasi": "^2.5.0",
+    "@ruby/3.3-wasm-wasi": "^2.6.2",
     "@ruby/wasm-wasi": "^2.5.0",
     "dexie": "^3.2.5",
     "dexie-react-hooks": "^1.1.7",

--- a/runruby-worker/src/index.ts
+++ b/runruby-worker/src/index.ts
@@ -9,7 +9,7 @@ const { withEncryptedSession, setSessionCookie } = createSession();
 const { preflight, corsify } = createCors({
   methods: ["GET", "PATCH", "POST"],
   // TODO: use env
-  origins: ["http://localhost:5173", "https://runruby.dev", "https://local.runruby.dev:5173"],
+  origins: ["http://localhost:5173", "https://runruby.dev", "https://local.runruby.dev:5173", "https://localhost:5173"],
   headers: {
     "Access-Control-Allow-Credentials": "true"
   }

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -42,6 +42,10 @@ export const Menu = () => {
     const path = `${parentNode ? parentNode.data.fullPath : ""}/${name}`;
     const object = (type === "leaf") ? writeFile(path, "") : mkdir(path);
 
+    if (!object) {
+      throw new Error(`Failed creating ${type === "leaf" ? "file" : "directory"} in the path: ${path}`);
+    }
+
     const id = nanoid();
     idsMap.set(object, id);
     refreshTreeData();

--- a/src/db.ts
+++ b/src/db.ts
@@ -30,14 +30,15 @@ export interface MarshaledDirectory {
 }
 
 export const mapToEntities = (data: DirectoryContents) => {
-  const result: { [key: string]: File | Directory } = {};
+  const result = new Map<string, File | Directory>();
 
   Object.entries(data).forEach(([key, value]) => {
     if ("data" in value) {
-      result[key] = new File(value.data);
+      result.set(key, new File(value.data));
     } else {
-      result[key] = new Directory(mapToEntities(value.contents));
+      result.set(key, new Directory(mapToEntities(value.contents)));
     }
   });
+
   return result;
 };

--- a/src/engines/wasi/wasi.ts
+++ b/src/engines/wasi/wasi.ts
@@ -1,6 +1,6 @@
 import { RubyVM } from "@ruby/wasm-wasi";
 import wasmUrl from "@ruby/3.3-wasm-wasi/dist/ruby+stdlib.wasm?url";
-import { Fd, PreopenDirectory, File, WASI, OpenFile, ConsoleStdout } from "@bjorn3/browser_wasi_shim";
+import {Fd, PreopenDirectory, File, WASI, OpenFile, ConsoleStdout, Inode} from "@bjorn3/browser_wasi_shim";
 
 import { wasiImports } from "./wasiImports";
 import { TRunParams, TSetString } from "../types";
@@ -11,10 +11,11 @@ import { composeInitialFS } from "../../fsInitializer.ts";
 const wasmModulePromise = fetch(wasmUrl).then((response) => WebAssembly.compileStreaming(response));
 
 const rubyStubsPath = "/usr/local/lib/ruby_gems";
+const emptyMap = new Map<string, Inode>();
 
-export const gemsDir = new PreopenDirectory("/gems", {});
-export const bundleDir = new PreopenDirectory("/.bundle", {});
-export const workDir: PreopenDirectory = new PreopenDirectory("/", {});
+export const gemsDir = new PreopenDirectory("/gems", emptyMap);
+export const bundleDir = new PreopenDirectory("/.bundle", emptyMap);
+export const workDir: PreopenDirectory = new PreopenDirectory("/", emptyMap);
 
 let FSInitialized = false;
 

--- a/src/engines/wasi/wasiImports.ts
+++ b/src/engines/wasi/wasiImports.ts
@@ -1,11 +1,4 @@
-import { Directory, OpenDirectory, WASI, wasi as wasiDefs } from "@bjorn3/browser_wasi_shim";
-
-function pathDirAndFile(path: string) {
-  const paths = path.split("/");
-  const filename = paths.pop() as string;
-  const dir_path = paths.join("/");
-  return { filename, dir_path };
-}
+import { WASI } from "@bjorn3/browser_wasi_shim";
 
 const tracedWasiImports = (wasi: WASI) => {
   for (const key in wasi.wasiImport) {
@@ -25,53 +18,6 @@ export const wasiImports = (wasi: WASI, options?: { debug?: boolean }) => {
   return {
     wasi_snapshot_preview1: {
       ...(options?.debug ? tracedWasiImports(wasi) : wasi.wasiImport),
-      path_filestat_set_times: () => wasiDefs.ERRNO_SUCCESS,
-      path_rename: (
-        fd: number,
-        old_path_ptr: number,
-        old_path_len: number,
-        new_fd: number,
-        new_path_ptr: number,
-        new_path_len: number
-      ): number => {
-        if (wasi.fds[fd] === undefined || wasi.fds[new_fd] == undefined) {
-          return wasiDefs.ERRNO_BADF;
-        }
-        const decoder = new TextDecoder("utf-8");
-        const buffer8 = new Uint8Array(wasi.inst.exports.memory.buffer);
-        const old_path = decoder.decode(
-          buffer8.slice(old_path_ptr, old_path_ptr + old_path_len)
-        );
-        const new_path = decoder.decode(
-          buffer8.slice(new_path_ptr, new_path_ptr + new_path_len)
-        );
-
-        if (new_fd === fd && (wasi.fds[fd] instanceof OpenDirectory)) {
-          const open_dir = wasi.fds[fd] as OpenDirectory;
-          const dir = open_dir.dir;
-          const clean_old_path = open_dir.clean_path(old_path);
-          const clean_new_path = open_dir.clean_path(new_path);
-          const old_path_entry = dir.get_entry_for_path(clean_old_path);
-          if (old_path_entry === null) {
-            return wasiDefs.ERRNO_NOENT;
-          }
-          if (dir.get_entry_for_path(clean_new_path) !== null) {
-            return wasiDefs.ERRNO_EXIST;
-          }
-
-          const { filename: new_filename, dir_path: new_dir_path } = pathDirAndFile(clean_new_path);
-          const new_dir = dir.create_entry_for_path(new_dir_path, true) as Directory;
-          new_dir.contents[new_filename] = old_path_entry;
-
-          const { filename: old_filename, dir_path: old_dir_path } = pathDirAndFile(clean_old_path);
-          const old_dir = dir.get_entry_for_path(old_dir_path) as Directory;
-          delete old_dir.contents[old_filename];
-
-          return wasiDefs.ERRNO_SUCCESS;
-        }
-
-        throw new Error(`path_rename not implemented yet: ${fd} ${old_path} -> ${new_fd} ${new_path}`);
-      }
     }
   };
 };

--- a/src/fsInitializer.ts
+++ b/src/fsInitializer.ts
@@ -33,7 +33,6 @@ Octokit.middleware.adapter :js
 # Now we can use Octokit as we would in a normal Ruby environment
 client = Octokit::Client.new
 user = client.user("matz")
-
 # And it just works 🚀
 pp({login: user.login, name: user.name, company: user.company})
 `;

--- a/src/fsMap.ts
+++ b/src/fsMap.ts
@@ -12,19 +12,25 @@ export type Entity = {
 export const idsMap = new Map<File | Directory | SyncOPFSFile, string>;
 
 export const sortChildren = (node: Directory, nodePath: string): Entity[] => {
-  const entries = Object.entries(node.contents).map((entry) => {
-    const id = idsMap.get(entry[1]);
-    const result = { id: id || nanoid(), name: entry[0], fullPath: `${nodePath ? nodePath + '/' : ''}${entry[0]}`, object: entry[1] };
+  const entries = Array.from(node.contents.entries()).map(([key, value]) => {
+    if (!(value instanceof Directory || value instanceof File || value instanceof SyncOPFSFile)) {
+      throw new Error(`Unexpected type in directory contents: ${key}`);
+    }
+
+    const id = idsMap.get(value);
+    const result = { id: id || nanoid(), name: key, fullPath: `${nodePath ? nodePath + '/' : ''}${key}`, object: value };
     if (!id) {
       setDirty(result.fullPath);
     }
-    idsMap.set(entry[1], result.id);
+    idsMap.set(value, result.id);
     return result;
   });
+
   entries.sort((a, b) => {
     if (a.object instanceof Directory && b.object instanceof File) return -1;
     if (b.object instanceof Directory && a.object instanceof File) return 1;
     return a.name < b.name ? -1 : 1;
   });
+
   return entries;
 };

--- a/src/stubs/bundler_stub.rb
+++ b/src/stubs/bundler_stub.rb
@@ -31,11 +31,13 @@ Bundler::Worker.prepend(Module.new do
   end
 end)
 
+
+require "uri"
 require "bundler/fetcher/compact_index"
 Bundler::Fetcher::CompactIndex.prepend(Module.new do
  def specs(gem_names)
    uri = "https://worker.runruby.dev/compact_index_specs?gems=#{gem_names.join(',')}"
-   response = JSON.parse(JS::Connection.new.request(URI(uri), Gem::Net::HTTP::Get.new(URI(uri))).body)
+   response = JSON.parse(JS::Connection.new.request(URI(uri), Gem::Net::HTTP::Get.new(URI(uri).request_uri)).body)
    if response["remainingGems"].empty?
      response["specs"]
    else

--- a/src/stubs/index.ts
+++ b/src/stubs/index.ts
@@ -1,24 +1,25 @@
-import { Directory, File, PreopenDirectory } from "@bjorn3/browser_wasi_shim";
+import {Directory, File, Inode, PreopenDirectory} from "@bjorn3/browser_wasi_shim";
 
 const rubyStubs = import.meta.glob("./**/*.rb", { as: "raw", eager: true });
 
 const getDirectory = (paths: string[], rootDir: PreopenDirectory) => {
   return paths.reduce((acc, pathPart) => {
-    if (acc.contents[pathPart] === undefined) {
-      acc.contents[pathPart] = new Directory({});
+    if (acc.contents.get(pathPart) === undefined) {
+      acc.contents.set(pathPart, new Directory([]))
     }
-    return acc.contents[pathPart] as Directory;
+    return acc.contents.get(pathPart) as Directory;
   }, rootDir.dir);
 }
 
 export const generateRubyStubsDir = (path: string) => {
-  const rootDir = new PreopenDirectory(path, {});
+  const emptyMap = new Map<string, Inode>();
+  const rootDir = new PreopenDirectory(path, emptyMap);
   const encoder = new TextEncoder();
   for (const [filePath, fileText] of Object.entries(rubyStubs)) {
     const paths = filePath.split("/").slice(1);
     const filename = paths.pop() as string;
     const directory = getDirectory(paths, rootDir);
-    directory.contents[filename] = new File(encoder.encode(fileText));
+    directory.contents.set(filename, new File(encoder.encode(fileText)));
   }
   return rootDir;
 }


### PR DESCRIPTION
This PR updates versions of `@ruby/3.3-wasm-wasi` and `@bjorn3/browser_wasi_shim`.

It also required some additional code changes as `Directory.contents` is a map and not a hash like before