### PR TITLE
Use `Map.prototype.entries` to walk file tree

### DIFF
--- a/src/engines/wasi/editorFS.ts
+++ b/src/engines/wasi/editorFS.ts
@@ -20,7 +20,7 @@ export interface FSFile {
 
 export const walkFileTree = (cb: ({ filename, contents }: FSFile) => void) => {
   const walk = (dir: Directory, path: string) => {
-    Object.entries(dir.contents).forEach(([name, file]) => {
+    for (const [name, file] of dir.contents.entries()) {
       if (file instanceof Directory) {
         walk(file, `${path}/${name}`);
       } else {
@@ -29,7 +29,7 @@ export const walkFileTree = (cb: ({ filename, contents }: FSFile) => void) => {
           contents: decode((file as File).data),
         });
       }
-    });
+    };
   };
 
   walk(workDir.dir, "");


### PR DESCRIPTION
`Object.entries` is empty for `Map` objects:

```
>> const map = new Map([[1, "one"]])
=> undefined
>> map
=> Map(1) {1 => 'one'}
>> Object.entries(map)
=> []
>> map.entries()
=> MapIterator {1 => 'one'}
```

Gist creation is failing I think because it's sending an empty files object, though I didn't test the whole flow locally because I didn't want to set up an oauth app. This at least generates a `files` object that looks correct.